### PR TITLE
Fixing link error on lgamma_r on windows

### DIFF
--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -175,9 +175,16 @@ pub fn inc_gamma(x: f64, p: f64) -> f64 {
 
 /// Compute the natural logarithm of the gamma function.
 #[inline]
+#[cfg(unix)]
 pub fn ln_gamma(x: f64) -> (f64, i32) {
     let mut sign: i32 = 0;
     let value = unsafe { m::lgamma_r(x, &mut sign) };
+    (value, sign)
+}
+#[cfg(windows)]
+pub fn ln_gamma(x: f64) -> (f64, i32) {
+    let mut sign: i32 = 0;
+    let value = unsafe { m::lgamma(x, &mut sign) };
     (value, sign)
 }
 

--- a/src/m.rs
+++ b/src/m.rs
@@ -10,11 +10,6 @@ extern {
     pub fn tgamma(x: c_double) -> c_double;
 }
 
-#[cfg(windows)]
-pub fn lgamma_r(x: c_double, sign: &mut c_int) -> c_double {
-    unsafe { lgamma(x, sign) }
-}
-
 #[cfg(test)]
 mod tests {
     use assert;

--- a/src/m.rs
+++ b/src/m.rs
@@ -3,8 +3,16 @@ use libc::{c_double, c_int};
 extern {
     pub fn erf(x: c_double) -> c_double;
     pub fn erfc(x: c_double) -> c_double;
+    #[cfg(unix)]
     pub fn lgamma_r(x: c_double, sign: &mut c_int) -> c_double;
+    #[cfg(windows)]
+    pub fn lgamma(x: c_double, sign: &mut c_int) -> c_double;
     pub fn tgamma(x: c_double) -> c_double;
+}
+
+#[cfg(windows)]
+pub fn lgamma_r(x: c_double, sign: &mut c_int) -> c_double {
+    unsafe { lgamma(x, sign) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hello, greetings.  This is to fix the link error that happens on Windows where lgamma_r() does not exist.  The equivalent in MSVC is actually called lgamma() with the sign output parameter (whereas in GNU, lgamma doesn't have a sign output parameter) 

I added conditonal compile configs in m.rs to link lgamma on windows and lgamma_r on unix.  Also, for windows, I created a lgamma_r function which simply delegates to lgamma.  This is so that the rest of the code can assume the existence of lgamma_r.

However, the cons is, it will cause a warning "unnecessary unsafe" in gamma.rs.  This is because I need to add an unsafe block in the "faked" lgamma_r for calling lgamma.

To fix that, I simply created a conditional compile in gamma.rs for ln_gamma() to call lgamma_r on unix and lgamma on windows.  Assuming ln_gamma() is now the wrapper, there is no point to fake lgamma_r() in m.rs, hence removed in the second commit. 

The tests all passed on both Mac OSX and Windows 10.

Please kindly review and let me know if you have any questions/comments.

Cheers,
Albert