### PR TITLE
Added wasm32 to conditional compilation for lgamma

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -13,12 +13,12 @@ extern "C" {
     pub fn lgamma(x: c_double, sign: &mut c_int) -> c_double;
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, target_arch = "wasm32"))]
 extern "C" {
     pub fn lgamma_r(x: c_double, sign: &mut c_int) -> c_double;
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, target_arch = "wasm32"))]
 #[inline(always)]
 pub unsafe fn lgamma(x: c_double, sign: &mut c_int) -> c_double {
     lgamma_r(x, sign)


### PR DESCRIPTION
This change allows this crate to be buildable for Wasm targets.