### PR TITLE
Make usable on no-alloc systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/special"
 homepage = "https://github.com/stainless-steel/special"
 repository = "https://github.com/stainless-steel/special"
 readme = "README.md"
-categories = ["algorithms", "science"]
+categories = ["algorithms", "science", "no-std::no-alloc"]
 keywords = ["beta", "error", "gamma"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@
 #[cfg(test)]
 extern crate assert;
 
+#[cfg(test)]
 extern crate alloc;
+
 extern crate libm;
 
 mod beta;


### PR DESCRIPTION
It's a pretty trivial change, but relevant when using this on embedded systems.