### PR TITLE
Lower the minimum required Rust version to 1.60 by exporting the `LambertW` trait in a less ambiguous way

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,5 @@ mod primitive;
 pub use beta::Beta;
 pub use error::Error;
 pub use gamma::Gamma;
-pub use lambert_w::LambertW;
+pub use crate::lambert_w::LambertW;
 pub use primitive::Primitive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ mod gamma;
 mod lambert_w;
 mod primitive;
 
+pub use crate::lambert_w::LambertW;
 pub use beta::Beta;
 pub use error::Error;
 pub use gamma::Gamma;
-pub use crate::lambert_w::LambertW;
 pub use primitive::Primitive;


### PR DESCRIPTION
It turns out that because I gave the `lambert_w` module the same name as the crate the import is ambiguous in all Rust versions prior to 1.72. By importing it in this much clearer way, Rust versions all the way back to 1.60 can compile it correctly.

I tested this with [`cargo-msrv`](https://github.com/foresterre/cargo-msrv).