### PR TITLE
Make the `std` feature take precedence over `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ keywords = ["beta", "error", "lambert-w", "gamma"]
 
 [features]
 default = ["no_std"]
+# Use `libm` to do certain math operations. This feature must be enabled if the `std` feature is disabled.
 no_std = ["lambert_w/libm"]
+# Link the standard library and use it for some computations. When this feature is disabled the crate is no_std compatible. This feature takes precedence over the `no_std` feature.
 std = ["lambert_w/std"]
 
 [dependencies]

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -28,7 +28,7 @@ macro_rules! implement {
     }
 }
 
-#[cfg(feature = "no_std")]
+#[cfg(all(feature = "no_std", not(feature = "std")))]
 #[path = "extrinsic.rs"]
 mod implementation;
 


### PR DESCRIPTION
This resolves #22.