### PR TITLE
Update `lambert_w` to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ elliptic = ["ellip"]
 
 [dependencies]
 ellip = { version = "1.1.0", default-features = false, optional = true }
-lambert_w = { version = "1", default-features = false, optional = true }
+lambert_w = { version = "2", default-features = false, optional = true }
 libm = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
I removed some deprecated functionality from the `lambert_w` crate.

The changes to that crate do not touch any of the API surface used by `special`, so this PR just updates the version that `special` uses and nothing else.