### PR TITLE
Upgrade ellip to 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ std = ["lambert_w?/std", "ellip?/std"]
 elliptic = ["ellip"]
 
 [dependencies]
-ellip = { version = "1.1.0", default-features = false, optional = true }
+ellip = { version = "1.1.1", default-features = false, optional = true }
 lambert_w = { version = "2", default-features = false, optional = true }
 libm = "0.2"
 


### PR DESCRIPTION
This `ellip` dependency upgrade to v1.1.1 fixes the incorrect argument reduction in certain branches of the Legendre functions (`Elliptic::inc_elliptic_pi`, `Elliptic::inc_elliptic_e`, and `Elliptic::elliptic_pi`) and improve the precision of `Elliptic::elliptic_pi` in near-diagonal cases as detailed in https://github.com/p-sira/ellip/pull/111.

This PR makes no change to the API of `special`.